### PR TITLE
chore: Update Named Resources after the Project Pivot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# media-metadata-manager
-An external media tagging and playlist management platform created for Coastal Hacks 2022.
+# public-beacon
+
+A public, crowd-sourced beach advisory and closure reporting database created for Coastal Hacks 2022.

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "codebase": "media-metadata-manager",
+    "codebase": "public-portal",
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint",
       "npm --prefix \"$RESOURCE_DIR\" run build"

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,10 +1,12 @@
 {
-  "name": "functions",
+  "name": "public-beacon-functions",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "functions",
+      "name": "public-beacon-functions",
+      "version": "0.1.0",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "functions",
+  "name": "public-beacon-functions",
+  "version": "0.1.0",
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,7 +5,7 @@ import * as cors from "cors";
 import { graphqlEndpoint } from "./graphql";
 
 // Initialize the Express App for the back end
-export const media_metadata_manager = (() => {
+export const public_beacon = (() => {
   const app = express();
 
   // Automatically allow cross-origin requests

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "media-metadata-manager",
+  "name": "public-portal-website",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "media-metadata-manager",
+      "name": "public-portal-website",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.9.0",

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "media-metadata-manager",
+  "name": "public-portal-website",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -15,6 +15,8 @@
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
     "firebase": "^9.8.3",
+    "graphql": "^16.5.0",
+    "graphql-request": "^4.3.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",

--- a/website/src/config/firebaseInitialization.ts
+++ b/website/src/config/firebaseInitialization.ts
@@ -1,14 +1,6 @@
 // Import the functions you need from the SDKs you need
-import { getAnalytics } from "firebase/analytics";
 import { initializeApp } from "firebase/app";
-import { connectAuthEmulator, getAuth } from "firebase/auth";
-import {
-  connectFirestoreEmulator,
-  doc,
-  getFirestore,
-} from "firebase/firestore";
 import { connectFunctionsEmulator, getFunctions } from "firebase/functions";
-import { connectStorageEmulator, getStorage } from "firebase/storage";
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
@@ -27,30 +19,35 @@ const firebaseConfig = {
 export const firebaseApp = initializeApp(firebaseConfig);
 
 // Initialize Firebase Analytics
-export const firebaseAnalytics = getAnalytics(firebaseApp);
+// NOTE: Disabled because it was not needed after the project pivot
+// export const firebaseAnalytics = getAnalytics(firebaseApp);
 
 // Initialize Firebase Auth
-export const firebaseAuth = getAuth(firebaseApp);
+// NOTE: Disabled because it was not needed after the project pivot
+// export const firebaseAuth = getAuth(firebaseApp);
 
 // Initialize Firestore
-const firestoreTemp = getFirestore(firebaseApp);
+// NOTE: Disabled because it was not needed after the project pivot
+// const firestoreTemp = getFirestore(firebaseApp);
 
 // Initialize Firebase Functions
 export const firebaseFunctions = getFunctions(firebaseApp);
 
 // Initialize Storage
-export const firebaseStorage = getStorage(firebaseApp);
+// NOTE: Disabled because it was not needed after the project pivot
+// export const firebaseStorage = getStorage(firebaseApp);
 
 // Configure emulators if not in a production environment
 if (process.env.NODE_ENV !== "production") {
-  connectAuthEmulator(firebaseAuth, "http://localhost:9099");
-  connectFirestoreEmulator(firestoreTemp, "localhost", 8080);
+  // connectAuthEmulator(firebaseAuth, "http://localhost:9099");
+  // connectFirestoreEmulator(firestoreTemp, "localhost", 8080);
   connectFunctionsEmulator(firebaseFunctions, "localhost", 5001);
-  connectStorageEmulator(firebaseStorage, "localhost", 9199);
+  // connectStorageEmulator(firebaseStorage, "localhost", 9199);
 }
 
 // Configure the hackathon-specific directory for Firestore
-export const firebaseFirestore = doc(
+// NOTE: Disabled because it was not needed after the project pivot
+/* export const firebaseFirestore = doc(
   firestoreTemp,
   "/hackathons/CostalHacks2022/"
-);
+); */

--- a/website/src/config/graphqlClient.ts
+++ b/website/src/config/graphqlClient.ts
@@ -8,7 +8,7 @@ import {
 
 /**
  * The basics of this logic were borrowed from the internal `_url(name)` method in the following file:
- * `/media-metadata-manager/website/node_modules/@firebase/functions/dist/index.esm2017.js
+ * `/website/node_modules/@firebase/functions/dist/index.esm2017.js
  */
 const getFirebaseFunctionsEndpointUrl = (endpointName: string) => {
   const projectId = firebaseApp.options.projectId;
@@ -21,7 +21,7 @@ const getFirebaseFunctionsEndpointUrl = (endpointName: string) => {
   return `https://${firebaseFunctions.region}-${projectId}.cloudfunctions.net/${endpointName}`;
 };
 
-const relativeGraphqlEndpoint = "media_metadata_manager/graphql";
+const relativeGraphqlEndpoint = "public_beacon/graphql";
 const absoluteGraphqlEndpoint = getFirebaseFunctionsEndpointUrl(
   relativeGraphqlEndpoint
 );
@@ -34,6 +34,7 @@ onIdTokenChanged(firebaseAuth, (user) => {
     user
       .getIdToken()
       .then((token) => {
+        console.debug("User authorization header set in the GraphQL Client");
         graphqlClient.setHeader("authorization", token);
       })
       .catch((error) => {
@@ -42,6 +43,7 @@ onIdTokenChanged(firebaseAuth, (user) => {
       });
   } else {
     // Remove the authorization headers when the user logs out
+    console.debug("User authorization header removed from the GraphQL Client");
     graphqlClient.setHeaders({});
   }
 });

--- a/website/src/config/graphqlClient.ts
+++ b/website/src/config/graphqlClient.ts
@@ -1,10 +1,5 @@
-import { onIdTokenChanged } from "firebase/auth";
 import { GraphQLClient } from "graphql-request";
-import {
-  firebaseApp,
-  firebaseAuth,
-  firebaseFunctions,
-} from "./firebaseInitialization";
+import { firebaseApp, firebaseFunctions } from "./firebaseInitialization";
 
 /**
  * The basics of this logic were borrowed from the internal `_url(name)` method in the following file:
@@ -28,7 +23,8 @@ const absoluteGraphqlEndpoint = getFirebaseFunctionsEndpointUrl(
 
 export const graphqlClient = new GraphQLClient(absoluteGraphqlEndpoint);
 
-onIdTokenChanged(firebaseAuth, (user) => {
+// NOTE: Disabled because it was not needed after the project pivot
+/* onIdTokenChanged(firebaseAuth, (user) => {
   if (user) {
     // Attach the authorization header when the user logs in or refreshes their token
     user
@@ -46,4 +42,4 @@ onIdTokenChanged(firebaseAuth, (user) => {
     console.debug("User authorization header removed from the GraphQL Client");
     graphqlClient.setHeaders({});
   }
-});
+}); */


### PR DESCRIPTION
Make all of the changes required in #6 to pivot this repo from `media-metadata-manger` to `public-beacon`.

Closes #6.