### PR TITLE
feat(functions/graphql): Create Country and Postal Code Interfaces

### DIFF
--- a/functions/src/@types/countries.d.ts
+++ b/functions/src/@types/countries.d.ts
@@ -1,0 +1,8 @@
+declare interface Country {
+  id: string;
+  name: string;
+}
+
+declare interface CreateCountryInput {
+  name: string;
+}

--- a/functions/src/@types/countries.d.ts
+++ b/functions/src/@types/countries.d.ts
@@ -1,6 +1,11 @@
-declare interface Country {
+declare interface CountryData {
   id: string;
   name: string;
+}
+
+declare interface Country extends CountryData {
+  postalCodes: () => PostalCode[];
+  postalCode: (id: GraphqlQueryId) => PostalCode;
 }
 
 declare interface CreateCountryInput {

--- a/functions/src/@types/graphql.d.ts
+++ b/functions/src/@types/graphql.d.ts
@@ -1,0 +1,7 @@
+declare interface GraphqlQueryId {
+  id: string;
+}
+
+declare interface GraphqlMutationInput<T> {
+  input: T;
+}

--- a/functions/src/@types/postalCodes.d.ts
+++ b/functions/src/@types/postalCodes.d.ts
@@ -1,0 +1,10 @@
+declare interface PostalCode {
+  id: string;
+  countryId: string;
+  postalCode: string;
+}
+
+declare interface CreatePostalCodeInput {
+  countryId: string;
+  postalCode: string;
+}

--- a/functions/src/graphql/countries/index.ts
+++ b/functions/src/graphql/countries/index.ts
@@ -1,0 +1,3 @@
+export { schemaString as countrySchemaString } from "./schema";
+export { queries as countryQueries } from "./queries";
+export { mutations as countryMutations } from "././mutations";

--- a/functions/src/graphql/countries/mutations.ts
+++ b/functions/src/graphql/countries/mutations.ts
@@ -1,10 +1,16 @@
+import { postalCodeQueries } from "../postalCodes";
+
 const createCountry = ({
   input,
 }: GraphqlMutationInput<CreateCountryInput>): Country => {
+  console.log("Running createCountry in Sandbox Mode.");
+  const id = input.name.replace(/[^a-zA-Z]/g, "");
   return {
     // Remove all non-alphabetical character
-    id: input.name.replace(/[^a-zA-Z]/g, ""),
+    id,
     name: input.name,
+    postalCodes: postalCodeQueries.postalCodes(id),
+    postalCode: postalCodeQueries.postalCode(id),
   };
 };
 

--- a/functions/src/graphql/countries/mutations.ts
+++ b/functions/src/graphql/countries/mutations.ts
@@ -1,0 +1,11 @@
+const createCountry = ({ input }: GraphqlMutationInput<CreateCountryInput>) => {
+  return {
+    // Remove all non-alphabetical character
+    id: input.name.replace(/[^a-zA-Z]/g, ""),
+    name: input.name,
+  };
+};
+
+export const mutations = {
+  createCountry,
+};

--- a/functions/src/graphql/countries/mutations.ts
+++ b/functions/src/graphql/countries/mutations.ts
@@ -1,4 +1,6 @@
-const createCountry = ({ input }: GraphqlMutationInput<CreateCountryInput>) => {
+const createCountry = ({
+  input,
+}: GraphqlMutationInput<CreateCountryInput>): Country => {
   return {
     // Remove all non-alphabetical character
     id: input.name.replace(/[^a-zA-Z]/g, ""),

--- a/functions/src/graphql/countries/queries.ts
+++ b/functions/src/graphql/countries/queries.ts
@@ -1,6 +1,8 @@
+import { postalCodeQueries } from "../postalCodes";
+
 const countryIds = ["Canada", "UnitedKingdom", "UnitedStates"];
 
-const countriesData = {
+const countriesData: { [key: string]: CountryData | null } = {
   Canada: {
     id: "Canada",
     name: "Canada",
@@ -13,22 +15,32 @@ const countriesData = {
     id: "UnitedStates",
     name: "United States",
   },
-} as { [key: string]: Country | null };
+};
 
 const countries = (): Country[] => {
+  console.log("Running countries in Sandbox Mode.");
   return countryIds.reduce((countriesList, countryId) => {
     const countryData = countriesData[countryId];
     if (countryData) {
-      countriesList.push(countryData);
+      countriesList.push({
+        ...countryData,
+        postalCodes: postalCodeQueries.postalCodes(countryId),
+        postalCode: postalCodeQueries.postalCode(countryId),
+      });
     }
     return countriesList;
   }, [] as Country[]);
 };
 
 const country = ({ id }: GraphqlQueryId): Country => {
+  console.log("Running country in Sandbox Mode.");
   const countryData = countriesData[id];
   if (countryData) {
-    return countryData;
+    return {
+      ...countryData,
+      postalCodes: postalCodeQueries.postalCodes(id),
+      postalCode: postalCodeQueries.postalCode(id),
+    };
   } else {
     throw new ReferenceError(`No country exists with id=${id}`);
   }

--- a/functions/src/graphql/countries/queries.ts
+++ b/functions/src/graphql/countries/queries.ts
@@ -15,11 +15,17 @@ const countriesData = {
   },
 } as { [key: string]: Country | null };
 
-const countries = () => {
-  return countryIds.map((id) => countriesData[id]);
+const countries = (): Country[] => {
+  return countryIds.reduce((countriesList, countryId) => {
+    const countryData = countriesData[countryId];
+    if (countryData) {
+      countriesList.push(countryData);
+    }
+    return countriesList;
+  }, [] as Country[]);
 };
 
-const country = ({ id }: GraphqlQueryId) => {
+const country = ({ id }: GraphqlQueryId): Country => {
   const countryData = countriesData[id];
   if (countryData) {
     return countryData;

--- a/functions/src/graphql/countries/queries.ts
+++ b/functions/src/graphql/countries/queries.ts
@@ -1,0 +1,34 @@
+const countryIds = ["Canada", "UnitedKingdom", "UnitedStates"];
+
+const countriesData = {
+  Canada: {
+    id: "Canada",
+    name: "Canada",
+  },
+  UnitedKingdom: {
+    id: "UnitedKingdom",
+    name: "United Kingdom",
+  },
+  UnitedStates: {
+    id: "UnitedStates",
+    name: "United States",
+  },
+} as { [key: string]: Country | null };
+
+const countries = () => {
+  return countryIds.map((id) => countriesData[id]);
+};
+
+const country = ({ id }: GraphqlQueryId) => {
+  const countryData = countriesData[id];
+  if (countryData) {
+    return countryData;
+  } else {
+    throw new ReferenceError(`No country exists with id=${id}`);
+  }
+};
+
+export const queries = {
+  countries,
+  country,
+};

--- a/functions/src/graphql/countries/schema.graphql
+++ b/functions/src/graphql/countries/schema.graphql
@@ -1,6 +1,8 @@
 type Country {
   id: ID!
   name: String!
+  postalCodes: [PostalCode!]!
+  postalCode(id: ID!): PostalCode!
 }
 
 input CreateCountryInput {

--- a/functions/src/graphql/countries/schema.graphql
+++ b/functions/src/graphql/countries/schema.graphql
@@ -1,0 +1,8 @@
+type Country {
+  id: ID!
+  name: String!
+}
+
+input CreateCountryInput {
+  name: String!
+}

--- a/functions/src/graphql/countries/schema.ts
+++ b/functions/src/graphql/countries/schema.ts
@@ -1,0 +1,13 @@
+// TODO: Figure out how to read from the actual schema.graphql file
+// Then remove this file!
+
+export const schemaString = `
+  type Country {
+    id: ID!
+    name: String!
+  }
+  
+  input CreateCountryInput {
+    name: String!
+  }
+`;

--- a/functions/src/graphql/countries/schema.ts
+++ b/functions/src/graphql/countries/schema.ts
@@ -5,6 +5,8 @@ export const schemaString = `
   type Country {
     id: ID!
     name: String!
+    postalCodes: [PostalCode!]!
+    postalCode(id: ID!): PostalCode!
   }
   
   input CreateCountryInput {

--- a/functions/src/graphql/index.ts
+++ b/functions/src/graphql/index.ts
@@ -5,7 +5,7 @@ import {
   countryQueries,
   countryMutations,
 } from "./countries";
-import { postalCodeSchemaString } from "./postalCodes";
+import { postalCodeSchemaString, postalCodeMutations } from "./postalCodes";
 import { schemaString as rootSchemaString } from "./schema";
 
 const schema = buildSchema(`
@@ -17,6 +17,7 @@ const schema = buildSchema(`
 const root = {
   ...countryQueries,
   ...countryMutations,
+  ...postalCodeMutations,
 };
 
 export const graphqlEndpoint = graphqlHTTP({

--- a/functions/src/graphql/index.ts
+++ b/functions/src/graphql/index.ts
@@ -5,11 +5,13 @@ import {
   countryQueries,
   countryMutations,
 } from "./countries";
+import { postalCodeSchemaString } from "./postalCodes";
 import { schemaString as rootSchemaString } from "./schema";
 
 const schema = buildSchema(`
   ${rootSchemaString}
   ${countrySchemaString}
+  ${postalCodeSchemaString}
 `);
 
 const root = {

--- a/functions/src/graphql/index.ts
+++ b/functions/src/graphql/index.ts
@@ -1,10 +1,13 @@
 import { graphqlHTTP } from "express-graphql";
 import { buildSchema } from "graphql";
+import {
+  countrySchemaString,
+} from "./countries";
+import { schemaString as rootSchemaString } from "./schema";
 
 const schema = buildSchema(`
-type Query {
-  hello: String
-}
+  ${rootSchemaString}
+  ${countrySchemaString}
 `);
 
 const root = {

--- a/functions/src/graphql/index.ts
+++ b/functions/src/graphql/index.ts
@@ -2,6 +2,8 @@ import { graphqlHTTP } from "express-graphql";
 import { buildSchema } from "graphql";
 import {
   countrySchemaString,
+  countryQueries,
+  countryMutations,
 } from "./countries";
 import { schemaString as rootSchemaString } from "./schema";
 
@@ -11,7 +13,8 @@ const schema = buildSchema(`
 `);
 
 const root = {
-  hello: () => "Hello World!",
+  ...countryQueries,
+  ...countryMutations,
 };
 
 export const graphqlEndpoint = graphqlHTTP({

--- a/functions/src/graphql/postalCodes/index.ts
+++ b/functions/src/graphql/postalCodes/index.ts
@@ -1,0 +1,1 @@
+export { schemaString as postalCodeSchemaString } from "./schema";

--- a/functions/src/graphql/postalCodes/index.ts
+++ b/functions/src/graphql/postalCodes/index.ts
@@ -1,1 +1,3 @@
 export { schemaString as postalCodeSchemaString } from "./schema";
+export { queries as postalCodeQueries } from "./queries";
+export { mutations as postalCodeMutations } from "././mutations";

--- a/functions/src/graphql/postalCodes/mutations.ts
+++ b/functions/src/graphql/postalCodes/mutations.ts
@@ -1,0 +1,14 @@
+const createPostalCode = ({
+  input,
+}: GraphqlMutationInput<CreatePostalCodeInput>): PostalCode => {
+  console.log("Running createPostalCode in Sandbox Mode.");
+  return {
+    id: input.postalCode,
+    countryId: input.countryId,
+    postalCode: input.postalCode,
+  };
+};
+
+export const mutations = {
+  createPostalCode,
+};

--- a/functions/src/graphql/postalCodes/queries.ts
+++ b/functions/src/graphql/postalCodes/queries.ts
@@ -1,0 +1,47 @@
+const postalCodesIds = ["123", "456", "789"];
+
+const postalCodesData: { [key: string]: PostalCode | null } = {
+  "123": {
+    id: "123",
+    countryId: "Canada",
+    postalCode: "123",
+  },
+  "456": {
+    id: "456",
+    countryId: "UnitedStates",
+    postalCode: "456",
+  },
+  "789": {
+    id: "789",
+    countryId: "UnitedStates",
+    postalCode: "789",
+  },
+};
+
+const postalCodes = (countryId: string) => (): PostalCode[] => {
+  console.log("Running postalCodes in Sandbox Mode.");
+  return postalCodesIds.reduce((postalCodeList, postalCodeId) => {
+    const postalCodeData = postalCodesData[postalCodeId];
+    if (postalCodeData && postalCodeData.countryId === countryId) {
+      postalCodeList.push(postalCodeData);
+    }
+    return postalCodeList;
+  }, [] as PostalCode[]);
+};
+
+const postalCode =
+  (countryId: string) =>
+  ({ id }: GraphqlQueryId): PostalCode => {
+    console.log("Running postalCode in Sandbox Mode.");
+    const postalCodeData = postalCodesData[id];
+    if (postalCodeData && postalCodeData.countryId === countryId) {
+      return postalCodeData;
+    } else {
+      throw new ReferenceError(`No postal code exists with id=${id}`);
+    }
+  };
+
+export const queries = {
+  postalCodes,
+  postalCode,
+};

--- a/functions/src/graphql/postalCodes/schema.graphql
+++ b/functions/src/graphql/postalCodes/schema.graphql
@@ -1,0 +1,10 @@
+type PostalCode {
+  id: ID!
+  countryId: ID!
+  postalCode: String!
+}
+
+input CreatePostalCodeInput {
+  countryId: ID!
+  postalCode: String!
+}

--- a/functions/src/graphql/postalCodes/schema.ts
+++ b/functions/src/graphql/postalCodes/schema.ts
@@ -1,0 +1,15 @@
+// TODO: Figure out how to read from the actual schema.graphql file
+// Then remove this file!
+
+export const schemaString = `
+  type PostalCode {
+    id: ID!
+    countryId: ID!
+    postalCode: String!
+  }
+
+  input CreatePostalCodeInput {
+    countryId: ID!
+    postalCode: String!
+  }
+`;

--- a/functions/src/graphql/schema.graphql
+++ b/functions/src/graphql/schema.graphql
@@ -10,4 +10,5 @@ type Query {
 
 type Mutation {
   createCountry(input: CreateCountryInput!): Country!
+  createPostalCode(input: CreatePostalCodeInput): PostalCode!
 }

--- a/functions/src/graphql/schema.graphql
+++ b/functions/src/graphql/schema.graphql
@@ -1,0 +1,13 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Query {
+  countries: [Country!]!
+  country(id: ID!): Country!
+}
+
+type Mutation {
+  createCountry(input: CreateCountryInput!): Country!
+}

--- a/functions/src/graphql/schema.ts
+++ b/functions/src/graphql/schema.ts
@@ -14,5 +14,6 @@ export const schemaString = `
   
   type Mutation {
     createCountry(input: CreateCountryInput!): Country!
+    createPostalCode(input: CreatePostalCodeInput): PostalCode!
   }
 `;

--- a/functions/src/graphql/schema.ts
+++ b/functions/src/graphql/schema.ts
@@ -1,0 +1,18 @@
+// TODO: Figure out how to read from the actual schema.graphql file
+// Then remove this file!
+
+export const schemaString = `
+  schema {
+    query: Query
+    mutation: Mutation
+  }
+  
+  type Query {
+    countries: [Country!]!
+    country(id: ID!): Country!
+  }
+  
+  type Mutation {
+    createCountry(input: CreateCountryInput!): Country!
+  }
+`;


### PR DESCRIPTION
Create the GraphQL Schema and basic GraphQL Resolver structure required for the Countries and Postal Codes.

Note that at this point I'm unable to figure out how to read `.graphql` files from TypeScript, so while the `schema.graphql` files exist now, only the `schema.ts` files are actually used.

In addition, the resolver logic is currently for static data, to be replaced with the actual Firestore logic later.

### Testing:

#### Query Operations

**Query:**

```graphql
query {
  countries {
    id
    name
    postalCodes {
      id
      countryId
      postalCode
    }
  }
  
  country(id: "UnitedStates") {
    name
    postalCode(id: "456") {
      postalCode
    }
  }
}
```

**Result:**

```json
{
  "data": {
    "countries": [
      {
        "id": "Canada",
        "name": "Canada",
        "postalCodes": [
          {
            "id": "123",
            "countryId": "Canada",
            "postalCode": "123"
          }
        ]
      },
      {
        "id": "UnitedKingdom",
        "name": "United Kingdom",
        "postalCodes": []
      },
      {
        "id": "UnitedStates",
        "name": "United States",
        "postalCodes": [
          {
            "id": "456",
            "countryId": "UnitedStates",
            "postalCode": "456"
          },
          {
            "id": "789",
            "countryId": "UnitedStates",
            "postalCode": "789"
          }
        ]
      }
    ],
    "country": {
      "name": "United States",
      "postalCode": {
        "postalCode": "456"
      }
    }
  }
}
```

**Logs:**

```
01:16:56 | function[us-central1-public_beacon] Beginning execution of "public_beacon"
01:16:56 I function[us-central1-public_beacon] Running countries in Sandbox Mode.
01:16:56 I function[us-central1-public_beacon] Running postalCodes in Sandbox Mode.
01:16:56 I function[us-central1-public_beacon] Running postalCodes in Sandbox Mode.
01:16:56 I function[us-central1-public_beacon] Running postalCodes in Sandbox Mode.
01:16:56 I function[us-central1-public_beacon] Running country in Sandbox Mode.
01:16:56 I function[us-central1-public_beacon] Running postalCode in Sandbox Mode.
01:16:56 I function[us-central1-public_beacon] Finished "public_beacon" in ~1s
```

**Notes:**

By the logs above we can that any of the resolvers that are not directly used are not called (i.e. not calling `postalCode` for the `countries` query, and not calling `postalCodes` for the `country` query. This is really important because it means we will not be making additional, unnecessary Firestore calls once we hook that up.

#### Mutation Operations

**Query:**

```graphql
mutation {
  createCountry(input:{
    name: "People's Republic of China"
  }) {
    id
    name
  }
  
  createPostalCode(input: {
    countryId: "UnitedStates"
    postalCode: "123456789"
  }) {
    id
    countryId,
    postalCode
  }
}
```

**Result:**

```json
{
  "data": {
    "createCountry": {
      "id": "PeoplesRepublicofChina",
      "name": "People's Republic of China"
    },
    "createPostalCode": {
      "id": "123456789",
      "countryId": "UnitedStates",
      "postalCode": "123456789"
    }
  }
}
```

**Logs:**

```
01:23:18 I function[us-central1-public_beacon] Beginning execution of "public_beacon"
01:23:18 I function[us-central1-public_beacon] Running createCountry in Sandbox Mode.
01:23:18 I function[us-central1-public_beacon] Running createPostalCode in Sandbox Mode.
01:23:18 I function[us-central1-public_beacon] Finished "public_beacon" in ~1s
```